### PR TITLE
Local Open Scope - fix word order.

### DIFF
--- a/cad.v
+++ b/cad.v
@@ -19,7 +19,7 @@ Import ord.
 
 Local Open Scope nat_scope.
 Local Open Scope ring_scope. 
-Open Local Scope quotient_scope.
+Local Open Scope quotient_scope.
 
 Section EqFormula.
 

--- a/expansiblefracpoly.v
+++ b/expansiblefracpoly.v
@@ -24,7 +24,7 @@ Unset Printing Implicit Defensive.
 
 Import GRing.Theory.
 Local Open Scope ring_scope.
-Open Local Scope quotient_scope.
+Local Open Scope quotient_scope.
 
 Section ExpansibleFracpoly.
 

--- a/fracrev.v
+++ b/fracrev.v
@@ -13,8 +13,8 @@ Unset Strict Implicit.
 Unset Printing Implicit Defensive.
 
 Import GRing.Theory.
-Open Local Scope ring_scope.
-Open Local Scope quotient_scope.
+Local Open Scope ring_scope.
+Local Open Scope quotient_scope.
 
 Reserved Notation "{ 'fracpoly' T }" (at level 0, format "{ 'fracpoly'  T }").
 Reserved Notation "x %:F" (at level 2, format "x %:F").

--- a/fraction.v
+++ b/fraction.v
@@ -15,8 +15,8 @@ Unset Strict Implicit.
 Unset Printing Implicit Defensive.
 
 Import GRing.Theory.
-Open Local Scope ring_scope.
-Open Local Scope quotient_scope.
+Local Open Scope ring_scope.
+Local Open Scope quotient_scope.
 
 Reserved Notation "{ 'ratio' T }" (at level 0, format "{ 'ratio'  T }").
 Reserved Notation "{ 'fraction' T }" (at level 0, format "{ 'fraction'  T }").

--- a/polyall.v
+++ b/polyall.v
@@ -17,7 +17,7 @@ Require Import polyorder.
 
 Import GRing.Theory.
 
-Open Local Scope ring_scope.
+Local Open Scope ring_scope.
 
 Set Implicit Arguments.
 Unset Strict Implicit.

--- a/polydec.v
+++ b/polydec.v
@@ -14,7 +14,7 @@ Require Import xseq polyorder polyall.
 
 Import GRing.Theory.
 
-Open Local Scope ring_scope.
+Local Open Scope ring_scope.
 
 Set Implicit Arguments.
 Unset Strict Implicit.


### PR DESCRIPTION
I had to change the word order to "Local Open ...." to compile with Coq 8.8.